### PR TITLE
Changes to self assessment response listing, fix sorting grade options

### DIFF
--- a/backend/src/controllers/course_controller.js
+++ b/backend/src/controllers/course_controller.js
@@ -43,20 +43,17 @@ router.get('/instance/:courseId', async (req, res) => {
     res.status(401).json({ error: 'You are not registered on this course' })
     return
   }
-  const tasks = await taskService.getUserTasksForCourse(courseId, req.lang, user.id)
-  // This is pretty ugly, but the speed-up is around 5-10x when doing two queries.
-  instance.dataValues.tasks = tasks
   const courseRole = instance.people[0].course_person.role
   if (courseRole !== 'TEACHER') {
     const teachers = await personService.getCourseTeachers(courseId)
     instance.dataValues.people = teachers
   } else {
-    const people = await personService.getPeopleOnCourse(courseId, instance.dataValues.tasks.map(task => task.id))
+    const people = await personService.getPeopleOnCourse(courseId, instance.tasks.map(task => task.id))
     instance.dataValues.people = people
   }
   instance.dataValues.courseRole = courseRole
 
-  instance.tasks = instance.dataValues.tasks.map(task => ({
+  instance.tasks = instance.tasks.map(task => ({
     ...task,
     types: task.types.map(ttype => ({ ...ttype, name: `${ttype.type_header.name} ${ttype.name}` })
     )

--- a/backend/src/services/course_service.js
+++ b/backend/src/services/course_service.js
@@ -2,6 +2,8 @@ const {
   Course,
   CourseInstance,
   Person,
+  Task,
+  TaskResponse,
   Type,
   SelfAssessment,
   AssessmentResponse,
@@ -20,6 +22,12 @@ const assessmentAttributes = lang => [
   'show_feedback',
   'course_instance_id']
 const typeAttributes = lang => ['id', [`${lang}_name`, 'name']]
+const taskAttributes = lang => [
+  'course_instance_id',
+  'id',
+  [`${lang}_name`, 'name'],
+  [`${lang}_description`, 'description'],
+  'max_points']
 
 const getCourseInstancesOfCourse = async (courseId, user, lang) => {
   const instances = (await CourseInstance.findAll({
@@ -55,24 +63,40 @@ const getInstanceWithRelatedData = (instanceId, lang, userId) => (
   CourseInstance.find({
     where: { id: instanceId },
     attributes: instanceAttributes(lang),
-    include: [
-      {
-        model: SelfAssessment,
-        attributes: assessmentAttributes(lang),
-        include: { model: AssessmentResponse, where: { person_id: userId }, required: false }
-      },
-      {
-        model: Person,
-        where: { id: userId }
-      },
-      {
-        model: TypeHeader,
-        attributes: courseAttributes(lang),
-        include: {
-          model: Type,
-          attributes: typeAttributes(lang)
+    include: [{
+      model: Task,
+      separate: true,
+      where: { course_instance_id: instanceId },
+      attributes: taskAttributes(lang),
+      include: [
+        { model: TaskResponse, where: { person_id: userId }, required: false },
+        { model: Type,
+          attributes: typeAttributes(lang),
+          include: {
+            model: TypeHeader,
+            where: { course_instance_id: instanceId },
+            attributes: typeAttributes(lang)
+          }
         }
+      ]
+    },
+    {
+      model: SelfAssessment,
+      attributes: assessmentAttributes(lang),
+      include: { model: AssessmentResponse, where: { person_id: userId }, required: false }
+    },
+    {
+      model: Person,
+      where: { id: userId }
+    },
+    {
+      model: TypeHeader,
+      attributes: courseAttributes(lang),
+      include: {
+        model: Type,
+        attributes: typeAttributes(lang)
       }
+    }
     ]
   })
 )

--- a/frontend/src/containers/SelfAssesmentList/SelfAssesmentListPage.js
+++ b/frontend/src/containers/SelfAssesmentList/SelfAssesmentListPage.js
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types'
 import { connect } from 'react-redux'
 import { withLocalize } from 'react-localize-redux'
 import { Link, Switch, Route, Redirect, withRouter } from 'react-router-dom'
-import { Container, Loader, Accordion, Button, Icon, Table, Segment, Header } from 'semantic-ui-react'
+import { Container, Loader, Accordion, Button, Icon, Table, Pagination, Segment, Header } from 'semantic-ui-react'
 import { CSVLink } from 'react-csv'
 
 import { getResponsesBySelfAssesment, updateVerificationAndFeedback } from '../../api/selfassesment'
@@ -15,35 +15,60 @@ const replaceQuotesAndLineBreaks = string => (
   string.replace(/["]/g, '""').replace(/(\r\n|\n|\r)/gm, ' ')
 )
 
+const mapDifferenceColor = (diff) => {
+  if (Math.abs(diff) > 2) return 'red'
+  if (Math.abs(diff) > 1) return 'orange'
+  return 'black'
+}
+
 class SelfAssesmentListPage extends Component {
   constructor(props) {
     super(props)
     this.state = {
       loading: true,
       responses: [],
-      activeResponse: null
+      selectedResponses: [],
+      activeResponse: null,
+      updating: false,
+      successful: 0,
+      unSuccessful: 0,
+      responsesOnScreen: 20,
+      maxPages: 1,
+      activePage: 1
     }
   }
 
-  componentDidMount() {
-    getResponsesBySelfAssesment({ id: this.props.selfAssesmentId }).then(response => this.setState({
+  async componentDidMount() {
+    const response = await getResponsesBySelfAssesment({ id: this.props.selfAssesmentId })
+    this.setState({
       responses: response.data.data,
-      loading: false
-    }))
+      loading: false,
+      maxPages: Math.ceil(response.data.data.length / this.state.responsesOnScreen)
+    })
   }
 
   translate = id => this.props.translate(`SelfAssessmentList.SelfAssessmentListPage.${id}`)
 
-  regenarateFeedback = () => (
-    this.setState({ loading: true }, () => {
-      updateVerificationAndFeedback(this.props.selfAssesmentId).then((response) => {
-        this.setState({
-          responses: response.data,
-          loading: false
+  regenarateFeedback = async () => {
+    await this.setState({ loading: true, updating: true, successful: 0, unSuccessful: 0 })
+    await Promise.all(this.state.selectedResponses.map(async (resp) => {
+      try {
+        const response = await updateVerificationAndFeedback(resp.id)
+        const filtered = [response.data, ...this.state.responses.filter(r => resp.id !== r.id)]
+        const filteredSelected = this.state.selectedResponses.filter(r => resp.id !== r.id)
+        await this.setState({
+          responses: filtered,
+          selectedResponses: filteredSelected,
+          successful: this.state.successful + 1
         })
-      }).catch(() => this.setState({ loading: false }))
-    })
-  )
+      } catch (e) {
+        await this.setState({
+          unSuccessful: this.state.unSuccessful + 1
+        })
+      }
+    }))
+    this.setState({ loading: false, updating: false })
+  }
 
   formatToCsv = () => {
     const { responses } = this.state
@@ -73,6 +98,20 @@ class SelfAssesmentListPage extends Component {
     return formatted
   }
 
+  selectResponse = (e, { value }) => {
+    const { selectedResponses } = this.state
+    if (selectedResponses.find(resp => resp.id === value)) {
+      this.setState({ selectedResponses: selectedResponses.filter(resp => resp.id !== value) })
+    } else {
+      const response = this.state.responses.find(resp => resp.id === value)
+      this.setState({ selectedResponses: [...selectedResponses, response] })
+    }
+  }
+
+  selectAll = () => {
+    this.setState({ selectedResponses: [...this.state.responses] })
+  }
+
   findVerifiactionGrade = (verification, categoryName) => {
     const category = verification.categoryVerifications.find(c => c.categoryName === categoryName)
     if (!category) {
@@ -81,9 +120,160 @@ class SelfAssesmentListPage extends Component {
     return category.earnedGrade.name
   }
 
-  renderList = () => (
-    <Container>
-      <Accordion
+  responseAccordion = response => (
+    <Accordion
+      styled
+      fluid
+      panels={[{
+        key: response.id,
+        title: `${response.person.studentnumber} ${response.person.name}`,
+        content: (
+          <Accordion.Content key={response.id}>
+            <Button
+              as={Link}
+              to={`/selfassesment/list/${this.props.selfAssesmentId}/${response.id}`}
+              basic
+              onClick={() => this.setState({ activeResponse: response })}
+            >
+              <span>{this.translate('inspect')}</span>
+              <Icon name="angle double right" />
+            </Button>
+            {response.response.assessmentType === 'category' ? (
+              <Table collapsing compact="very">
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell style={{ textTransform: 'capitalize' }}>{this.translate('category')}</Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">{this.translate('self_assessment')}</Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">{this.translate('machine_review')}</Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  {response.response.questionModuleResponses.map(qmResponse => (
+                    <Table.Row key={qmResponse.id}>
+                      <Table.Cell>{qmResponse.name}</Table.Cell>
+                      <Table.Cell textAlign="center">{qmResponse.grade}</Table.Cell>
+                      <Table.Cell textAlign="center">
+                        {this.findVerifiactionGrade(response.response.verification, qmResponse.name)}
+                      </Table.Cell>
+                    </Table.Row>
+                  ))}
+                </Table.Body>
+              </Table>
+            ) : null}
+            {response.response.finalGradeResponse ? (
+              <Table collapsing compact="very">
+                <Table.Header>
+                  <Table.Row>
+                    <Table.HeaderCell />
+                    <Table.HeaderCell textAlign="center">{this.translate('self_assessment')}</Table.HeaderCell>
+                    <Table.HeaderCell textAlign="center">{this.translate('machine_review')}</Table.HeaderCell>
+                  </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                  <Table.Row>
+                    <Table.Cell><strong>{this.translate('final_grade')}</strong></Table.Cell>
+                    <Table.Cell textAlign="center">{response.response.finalGradeResponse.grade}</Table.Cell>
+                    <Table.Cell textAlign="center">
+                      {response.response.verification.overallVerification.minGrade}–
+                      {response.response.verification.overallVerification.maxGrade}
+                    </Table.Cell>
+                  </Table.Row>
+                </Table.Body>
+              </Table>
+            ) : null}
+          </Accordion.Content>
+        )
+      }]}
+    />
+  )
+
+  responseDifferences = response => (
+    response.response.verification.categoryVerifications.map(c => (
+      <span style={{ color: mapDifferenceColor(c.wantedGrade.difference) }}>{c.wantedGrade.difference}, </span>
+    ))
+  )
+
+  finalGradeMatches = response => (
+    response.response.verification.overallVerification.minGrade === response.response.finalGradeResponse.grade
+    || response.response.verification.overallVerification.maxGrade === response.response.finalGradeResponse.grade
+  )
+
+  handlePaginationChange = (e, { activePage }) => (
+    this.setState({ activePage })
+  )
+
+  renderUpdating = () => (
+    <Segment> success: {this.state.successful}, fail: {this.state.unSuccessful} </Segment>
+  )
+
+  renderList = () => {
+    const { selectedResponses, responses, updating, activePage, responsesOnScreen } = this.state
+    const notSelected = responses.filter(r => !selectedResponses.find(sr => sr === r))
+    const displayed = notSelected.slice((activePage - 1) * responsesOnScreen, activePage * responsesOnScreen)
+    return (
+      <Container>
+        { updating ? this.renderUpdating() : undefined }
+        <Button content="valitse kaikki" onClick={this.selectAll} />
+        <Button content="poista valinnat" onClick={() => this.setState({ selectedResponses: [] })} />
+        {this.state.loading ? <Loader active /> :
+        <Table>
+          <Table.Header>
+            <Table.Row>
+              <Table.HeaderCell>selected</Table.HeaderCell>
+              <Table.HeaderCell>student</Table.HeaderCell>
+              <Table.HeaderCell>differences</Table.HeaderCell>
+              <Table.HeaderCell>last updated</Table.HeaderCell>
+            </Table.Row>
+          </Table.Header>
+          <Table.Body>
+            {selectedResponses.map(response => (
+              <Table.Row negative={!this.finalGradeMatches(response)}>
+                <Table.Cell>
+                  <Button
+                    basic
+                    color="green"
+                    icon="checkmark"
+                    value={response.id}
+                    onClick={this.selectResponse}
+                  />
+                </Table.Cell>
+                <Table.Cell>
+                  {this.responseAccordion(response)}
+                </Table.Cell>
+                <Table.Cell>{this.responseDifferences(response)}</Table.Cell>
+                <Table.Cell>{new Date(response.updated_at).toLocaleDateString()}</Table.Cell>
+              </Table.Row>
+            ))}
+            <Table.Row>
+              <Table.Cell>
+                <Pagination
+                  activePage={this.state.activePage}
+                  onPageChange={this.handlePaginationChange}
+                  totalPages={this.state.maxPages}
+                />
+              </Table.Cell>
+            </Table.Row>
+            {displayed.map(response => (
+              <Table.Row negative={!this.finalGradeMatches(response)}>
+                <Table.Cell>
+                  <Button
+                    basic
+                    color="red"
+                    icon="x"
+                    value={response.id}
+                    onClick={this.selectResponse}
+                  />
+                </Table.Cell>
+                <Table.Cell>
+                  {this.responseAccordion(response)}
+                </Table.Cell>
+                <Table.Cell>{this.responseDifferences(response)}</Table.Cell>
+                <Table.Cell>{new Date(response.updated_at).toLocaleDateString()}</Table.Cell>
+              </Table.Row>
+          ))}
+          </Table.Body>
+        </Table>}
+        {/* <Accordion
         fluid
         styled
         panels={this.state.responses.map(response => ({
@@ -135,7 +325,10 @@ class SelfAssesmentListPage extends Component {
                     <Table.Row>
                       <Table.Cell><strong>{this.translate('final_grade')}</strong></Table.Cell>
                       <Table.Cell textAlign="center">{response.response.finalGradeResponse.grade}</Table.Cell>
-                      <Table.Cell textAlign="center">{ /* konearvio */ }</Table.Cell>
+                      <Table.Cell textAlign="center">
+                        {response.response.verification.overallVerification.minGrade}–
+                        {response.response.verification.overallVerification.maxGrade}
+                      </Table.Cell>
                     </Table.Row>
                   </Table.Body>
                 </Table>
@@ -143,9 +336,10 @@ class SelfAssesmentListPage extends Component {
             </Accordion.Content>
           )
         }))}
-      />
-    </Container>
-  )
+      /> */}
+      </Container>
+    )
+  }
 
   renderResponse = () => {
     if (this.state.activeResponse === null) return <Redirect to={`/selfassesment/list/${this.props.selfAssesmentId}`} />
@@ -175,7 +369,7 @@ class SelfAssesmentListPage extends Component {
   }
 
   render() {
-    if (this.state.loading) return <Loader active />
+    // if (this.state.loading) return <Loader active />
     return (
       <div className="SelfAssesmentListPage">
         <Container>

--- a/frontend/src/containers/SelfAssessmentForm/utils.js
+++ b/frontend/src/containers/SelfAssessmentForm/utils.js
@@ -2,27 +2,28 @@ import { getByCourse } from '../../api/grades'
 
 const lang = localStorage.getItem('lang')
 
-const findPre = (a, b, data) => {
+export const findPre = (a, b, data) => {
+  if (a.id === b.id) return false
   let iterator = { ...a }
-  if (iterator.prerequisite === b.id) {
-    return true
-  }
-  const prerequisiteFinder = d => d.id === iterator.prerequisite
-  while (iterator.prerequisite) {
-    iterator = data.find(prerequisiteFinder)
-    if (a.id === b.id) {
+  const prerequisiteFinder = i => (i ? data.find((d => d.id === i)) : null)
+
+  while (iterator) {
+    if (iterator.id === b.id) {
       return true
     }
+    iterator = prerequisiteFinder(iterator.prerequisite)
   }
   return false
 }
 
-export const gradeOptions = async (courseInstanceId) => {
-  const grades = await getByCourse({ id: courseInstanceId })
-  const { data } = grades.data
-  data.sort((a, b) => {
+export const sortGrades = (data) => {
+  const sorted = [...data]
+  sorted.sort((a, b) => {
     if (!a.prerequisite && !b.prerequisite) {
       return Number.parseInt(a.name, 0) - Number.parseInt(b.name, 0)
+    }
+    if (a.id === b.id) {
+      return 0
     }
     if (!a.prerequisite) {
       return -1
@@ -39,8 +40,36 @@ export const gradeOptions = async (courseInstanceId) => {
     }
     return 0
   })
-  return data.map(d => ({ text: d.name, value: d.id }))
+  return sorted
 }
+
+
+export const detectCycle = (grade, data) => {
+  let cyclic = grade
+  while (cyclic) {
+    cyclic = data.find(g => (g.id === cyclic.prerequisite)) //eslint-disable-line
+    if (cyclic) {
+      if (cyclic.id === grade.id) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+export const gradeOptions = async (courseInstanceId) => {
+  const grades = await getByCourse({ id: courseInstanceId })
+  const { data } = grades.data
+  const isCyclic = data.some(grade => detectCycle(grade, data))
+  if (isCyclic) {
+    return data.map(d => ({ text: d.name, value: d.id }))
+  }
+  const sorted = sortGrades(data)
+  return sorted.map(d => ({ text: d.name, value: d.id }))
+}
+
+
+
 
 export const objectiveGrades = () => {
   switch (lang) {

--- a/frontend/src/tests/utils/utils.test.js
+++ b/frontend/src/tests/utils/utils.test.js
@@ -1,0 +1,199 @@
+import { findPre, sortGrades, detectCycle } from '../../containers/SelfAssessmentForm/utils'
+
+const data = [
+  {
+    id: 21,
+    name: 'Hylätty',
+    prerequisite: null
+  },
+  {
+    id: 8,
+    name: 1,
+    prerequisite: 21
+  },
+  {
+    id: 9,
+    name: 2,
+    prerequisite: 8
+  },
+  {
+    id: 10,
+    name: 3,
+    prerequisite: 9
+  },
+  {
+    id: 12,
+    name: 4,
+    prerequisite: 10
+  },
+  {
+    id: 15,
+    name: 5,
+    prerequisite: 12
+  }
+]
+
+describe('findPre', () => {
+  const a = data[2]
+  const b = data[1]
+
+
+  it('returns true when a prerequisite exits', () => {
+
+    const result = findPre(a, b, data)
+    expect(result).toEqual(true)
+  })
+
+  it('returns false when there is no prerequisite', () => {
+    const result = findPre(b, a, data)
+    expect(result).toEqual(false)
+  })
+
+  it('returns false when looking for prerequisites of a grade without any', () => {
+    const result = findPre(data[0], b, data)
+    expect(result).toEqual(false)
+  })
+
+  it('returns true when checking against grade without any prerequisites ', () => {
+    const result = findPre(a, data[0], data)
+    expect(result).toEqual(true)
+  })
+  it('returns false when both grades are without prerequisites', () => {
+    const result = findPre(data[0], { id: -1, prerequisite: null }, data)
+    expect(result).toEqual(false)
+  })
+  it('return false when you compare same grades', () => {
+    const result = findPre(data[0], data[0], data)
+    expect(result).toEqual(false)
+  })
+
+  describe('Sort grades', () => {
+    it('sorts an already ordered array', () => {
+      const result = sortGrades(data)
+      expect(JSON.stringify(result)).toMatch(JSON.stringify(data))
+    })
+
+    it('sorts an unordered array', () => {
+      const unordered = [
+        {
+          id: 8,
+          name: 1,
+          prerequisite: 21
+        },
+
+        {
+          id: 12,
+          name: 4,
+          prerequisite: 10
+        },
+        {
+          id: 21,
+          name: 'Hylätty',
+          prerequisite: null
+        },
+        {
+          id: 15,
+          name: 5,
+          prerequisite: 12
+        },
+        {
+          id: 9,
+          name: 2,
+          prerequisite: 8
+        },
+        {
+          id: 10,
+          name: 3,
+          prerequisite: 9
+        }
+      ]
+      const result = sortGrades(unordered)
+      expect(JSON.stringify(result)).toMatch(JSON.stringify(data))
+    })
+
+    it('sorts a reversed array', () => {
+      const reversed = [
+        {
+          id: 15,
+          name: 5,
+          prerequisite: 12
+        },
+        {
+          id: 12,
+          name: 4,
+          prerequisite: 10
+        },
+        {
+          id: 10,
+          name: 3,
+          prerequisite: 9
+        },
+        {
+          id: 9,
+          name: 2,
+          prerequisite: 8
+        },
+        {
+          id: 8,
+          name: 1,
+          prerequisite: 21
+        },
+        {
+          id: 21,
+          name: 'Hylätty',
+          prerequisite: null
+        }
+      ]
+      const result = sortGrades(reversed)
+      expect(JSON.stringify(result)).toMatch(JSON.stringify(data))
+    })
+    it('returns an empty array when called with one', () => {
+      const result = sortGrades([])
+      expect(result).toHaveLength(0)
+    })
+  })
+  describe('Detect cycle', () => {
+    it('returns true when there is a cycle in prerequisites', () => {
+
+      const cyclic = [
+        {
+          id: 8,
+          name: 1,
+          prerequisite: 15
+        },
+
+        {
+          id: 12,
+          name: 4,
+          prerequisite: 10
+        },
+        {
+          id: 21,
+          name: 'Hylätty',
+          prerequisite: null
+        },
+        {
+          id: 15,
+          name: 5,
+          prerequisite: 12
+        },
+        {
+          id: 9,
+          name: 2,
+          prerequisite: 8
+        },
+        {
+          id: 10,
+          name: 3,
+          prerequisite: 9
+        }
+      ]
+      const result = cyclic.some(grade => detectCycle(grade, cyclic))
+      expect(result).toEqual(true)
+    })
+    it('returns false when there is not', () => {
+      const result = data.some(grade => detectCycle(grade, data))
+      expect(result).toEqual(false)
+    })
+  })
+})


### PR DESCRIPTION
- Sorting of grades fixed in self assessment responding
- Generating feedbacks is now done one per request
   - Responses can be selected or de-selected for generation
   - Assessment response list uses a table that shows 20 rows at a time
   - Any response that doesn't match the calculated overall grade are displayed in red
   - Individual category differences are displayed in-line next to the student name + when the response was last updated (feedback generated)